### PR TITLE
[ISSUE #7534] Use high performance concurrent set to replace copyonwr…

### DIFF
--- a/namesrv/src/test/java/org/apache/rocketmq/namesrv/routeinfo/RouteInfoManagerNewTest.java
+++ b/namesrv/src/test/java/org/apache/rocketmq/namesrv/routeinfo/RouteInfoManagerNewTest.java
@@ -130,7 +130,6 @@ public class RouteInfoManagerNewTest {
         topicList = TopicList.decode(content, TopicList.class);
         assertThat(topicList.getTopicList()).contains("TestTopic", "TestTopic1", "TestTopic2");
     }
-
     @Test
     public void registerBroker() {
         // Register master broker

--- a/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/TopicList.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/body/TopicList.java
@@ -17,11 +17,11 @@
 package org.apache.rocketmq.remoting.protocol.body;
 
 import java.util.Set;
-import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.ConcurrentHashMap;
 import org.apache.rocketmq.remoting.protocol.RemotingSerializable;
 
 public class TopicList extends RemotingSerializable {
-    private Set<String> topicList = new CopyOnWriteArraySet<>();
+    private Set<String> topicList = ConcurrentHashMap.newKeySet();
     private String brokerAddr;
 
     public Set<String> getTopicList() {


### PR DESCRIPTION
…iteset (#7583)

* fix ISSUE #7534

* reformat code

* Remove the useless unit test

---------

<!-- Please make sure the target branch is right. In most case, the target branch should be `develop`. -->

### Which Issue(s) This PR Fixes

<!-- Please ensure that the related issue has already been created, and [link this pull request to that issue using keywords](<https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword>) to ensure automatic closure. -->

Fixes #issue_id

### Brief Description

<!-- Write a brief description for your pull request to help the maintainer understand the reasons behind your changes. -->

### How Did You Test This Change?

<!-- In order to ensure the code quality of Apache RocketMQ, we expect every pull request to have undergone thorough testing. -->
